### PR TITLE
Using /opt/lumerical/interconnect path instead CMC and fixing call.

### DIFF
--- a/klayout_dot_config/pymacros/INTERCONNECT - WaferToWafer MC simulation.lym
+++ b/klayout_dot_config/pymacros/INTERCONNECT - WaferToWafer MC simulation.lym
@@ -255,7 +255,7 @@ def mc_wtw(topcell, layout, dbu, datadict):
     if string.find(version,"2.") &gt; -1:
       import commands
       print("Running INTERCONNECT")
-      commands.getstatusoutput('/CMC/tools/lumerical/INTERCONNECT-5.0.527/bin/interconnect')
+      commands.getstatusoutput('/opt/lumerical/interconnect/bin/interconnect -run %s' % filename2)
   
   elif sys.platform.startswith('darwin'):
     # OSX specific

--- a/klayout_dot_config/pymacros/INTERCONNECT - WithinWafer MC simulation.lym
+++ b/klayout_dot_config/pymacros/INTERCONNECT - WithinWafer MC simulation.lym
@@ -284,7 +284,7 @@ def mc_dtd(topcell, layout, dbu, datadict):
     if string.find(version,"2.") &gt; -1:
       import commands
       print("Running INTERCONNECT")
-      commands.getstatusoutput('/CMC/tools/lumerical/INTERCONNECT-5.0.527/bin/interconnect')
+      commands.getstatusoutput('/opt/lumerical/interconnect/bin/interconnect -run %s' % filename2)
   
   elif sys.platform.startswith('darwin'):
     # OSX specific

--- a/klayout_dot_config/pymacros/INTERCONNECT.lym
+++ b/klayout_dot_config/pymacros/INTERCONNECT.lym
@@ -131,7 +131,7 @@ if sys.platform.startswith('linux'):
   if string.find(version,"2.") &gt; -1:
     import commands
     print("Running INTERCONNECT")
-    commands.getstatusoutput('/CMC/tools/lumerical/INTERCONNECT-5.0.527/bin/interconnect')
+    commands.getstatusoutput('/opt/lumerical/interconnect/bin/interconnect -run %s' % filename2)
 
 elif sys.platform.startswith('darwin'):
   # OSX specific


### PR DESCRIPTION
This is the standard installation location for Linux packages.