### PR TITLE
FYI: a few suggestions from my side

### DIFF
--- a/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam Library.lym
+++ b/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam Library.lym
@@ -121,7 +121,7 @@ class Waveguide(PCellDeclarationHelper):
     super(Waveguide, self).__init__()
     # declare the parameters
     TECHNOLOGY = get_technology_by_name('EBeam')
-    self.param("path", self.TypeShape, "Path", default = Path([Point(0,0), Point(10,0), Point(10,10)], 0.5))
+    self.param("path", self.TypeShape, "Path", default = DPath([DPoint(0,0), DPoint(10,0), DPoint(10,10)], 0.5))
     self.param("radius", self.TypeDouble, "Radius", default = 5)
     self.param("width", self.TypeDouble, "Width", default = 0.5)
     self.param("adiab", self.TypeBoolean, "Adiabatic", default = False)
@@ -137,17 +137,14 @@ class Waveguide(PCellDeclarationHelper):
   def coerce_parameters_impl(self):
     pass
           
-  def can_create_from_shape(self, layout, shape, layer):
-    return shape.is_path()
+  def can_create_from_shape_impl(self):
+    return self.shape.is_path()
 
-  def transformation_from_shape(self, layout, shape, layer):
+  def transformation_from_shape_impl(self):
     return Trans(Trans.R0,0,0)
 
-  def parameters_from_shape(self, layout, shape, layer):
-    self._param_values = []
-    for pd in self._param_decls:
-      self._param_values.append(pd.default)
-    return self._param_values
+  def parameters_from_shape_impl(self):
+    self.path = self.shape.dpath
         
   def produce_impl(self):
 
@@ -263,9 +260,6 @@ class Waveguide(PCellDeclarationHelper):
     text.halign=halign
     shape = self.cell.shapes(LayerDevRecN).insert(text)
 
-    if self.cell.shapes(self.layout.guiding_shape_layer()).is_empty():
-      self.cell.shapes(self.layout.guiding_shape_layer()).insert(Path(path.get_points(), 0))
-    
 
 class ebeam_dc_halfring_straight(PCellDeclarationHelper):
   """

--- a/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
+++ b/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
@@ -545,7 +545,7 @@ class cavity_hole(PCellDeclarationHelper):
     # Provide a descriptive text for the cell
     return "cavity_hole(R=" + ('%.3f-%.3f' % (self.radius,self.gap) ) + ")"
 
-  def can_create_from_shape_impl(self, layout, shape, layer):
+  def can_create_from_shape(self, layout, shape, layer):
     return False
 
 
@@ -2594,7 +2594,7 @@ class Tapered_Ring(PCellDeclarationHelper):
     # Provide a descriptive text for the cell
     return "Tapered_Ring(R=" + ('%.3f-%.3f' % (self.radius,self.w_bot) ) + ")"
 
-  def can_create_from_shape_impl(self, layout, shape, layer):
+  def can_create_from_shape(self, layout, shape, layer):
     return False
 
 


### PR DESCRIPTION
These are two patches I came across while dealing with https://github.com/klayoutmatthias/klayout/issues/75. The Waveguide PCell patch will enable "life" guiding shapes - if you modify the guiding shapes, the PCell will follow. With the #75 fix, "create PCell from shape" will work as well.

I have only done some rough testing. Please consider them suggestions rather than fixes.

Best regards,

Matthias