### PR TITLE
updated layout_waveguide_relative

### DIFF
--- a/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
+++ b/klayout_dot_config/tech/EBeam/pymacros/SiEPIC_EBeam-dev Library.lym
@@ -1251,7 +1251,7 @@ def layout_waveguide_rel(cell, layer, start_point, points, w, radius):
   
     wg_path = DPath(a1, w)
 
-    npoints = points_per_circle(radius)
+    npoints = points_per_circle(radius/dbu)
     param = { "npoints": npoints, "radius": float(radius), "path": wg_path, "layer": layer }
 
     pcell = ly.create_cell("ROUND_PATH", "Basic", param )


### PR DESCRIPTION
Fixed the inconsistent units between call to points per circle and call to round path pcell. Input of "radius" should be in units of microns.